### PR TITLE
fix: allow disabling tracking of recent buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ A buffer can be pinned using `;;` to add it to the `marklist` and display it reg
     path = vim.fs.joinpath(vim.fn.stdpath('data'), 'dart'),
   },
 
+  -- Force the tabline to always be shown, even if no files are currently marked
+  -- May be useful if `buflist` is empty
+  always_show_tabline = true,
+
   -- Default mappings
   -- Set an individual mapping to an empty string to disable,
   mappings = {


### PR DESCRIPTION
Hi, cool plugin. Was playing around with it and ended up having the same desire to opt-out of tracking recent buffers as described in #1.

The changes introduced should result in identical behavior for any existing configs.