### PR TITLE
feat: configurable picker border

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ require('dart').setup({})
     -- argument to pass to vim.fn.fnamemodify `mods`, before displaying the file path in the picker
     -- e.g. ":t" for the filename, ":p:." for relative path to cwd
     path_format = ':t',
+    -- border style for the picker window
+    -- See `:h winborder` for options
+    border = 'rounded',
   },
 
   -- State persistence. Use Dart.read_session and Dart.write_session manually

--- a/lua/dart/init.lua
+++ b/lua/dart/init.lua
@@ -58,6 +58,9 @@ M.config = {
     -- argument to pass to vim.fn.fnamemodify `mods`, before displaying the file path in the picker
     -- e.g. ":t" for the filename, ":p:." for relative path to cwd
     path_format = ':t',
+    -- border style for the picker window
+    -- See `:h winborder` for options
+    border = 'rounded',
   },
 
   -- State persistence. Use Dart.read_session and Dart.write_session manually
@@ -566,7 +569,7 @@ Dart.pick = function()
     col = math.floor((vim.o.columns - (row_len + 2)) / 2),
     anchor = 'NW',
     style = 'minimal',
-    border = 'rounded',
+    border = M.config.picker.border,
     focusable = true,
   })
 end


### PR DESCRIPTION
I wanted to give this plugin a go, and got bummed that i could not use anything but rounded borders for the picker, so I added that as an config option.

I don't know how you feel about the "See `:h winborder` for options", but felt the easiest and clearest.