### PR TITLE
fix: fix tabline init/draw logic

### DIFF
--- a/tests/test_dart_spec.lua
+++ b/tests/test_dart_spec.lua
@@ -36,7 +36,11 @@ local do_dart_test = function(params)
 
   -- init
   for i, path in ipairs(params.paths) do
-    child.cmd('edit tests/dir/' .. path.src)
+    local cmd = 'edit'
+    if path.tab then
+      cmd = 'tabedit'
+    end
+    child.cmd(cmd .. ' tests/dir/' .. path.src)
 
     if params.mark_after and contains(params.mark_after, i) then
       child.lua([[Dart.mark()]])
@@ -187,7 +191,6 @@ T['with config no buflist'] = set {
         paths = {
           { src = 'unix/dir1/1.lua' },
         },
-        mark_after = {},
         config = { buflist = {} },
         wanted = '',
       },
@@ -322,7 +325,7 @@ T['init with always_show=false and no buflist'] = set {
         },
         type_keys = { [2] = ';u' },
         config = { buflist = {}, tabline = { always_show = false } },
-        ['vim.opt.showtabline'] = 2,
+        ['vim.opt.showtabline'] = 1,
       },
     },
     {
@@ -333,7 +336,7 @@ T['init with always_show=false and no buflist'] = set {
         },
         type_keys = { [2] = ';u' },
         config = { buflist = {}, tabline = { always_show = false } },
-        ['vim.opt.showtabline'] = 2,
+        ['vim.opt.showtabline'] = 1,
       },
     },
     {

--- a/tests/test_dart_spec.lua
+++ b/tests/test_dart_spec.lua
@@ -22,18 +22,19 @@ local eval_tabline = function(show_hl, show_action)
   return res
 end
 
+local contains = function(haystack, needle)
+  for _, n in ipairs(haystack) do
+    if n == needle then
+      return true
+    end
+  end
+  return false
+end
+
 local do_dart_test = function(params)
   child.lua('require("dart").setup(...)', { params.config })
 
-  local contains = function(haystack, needle)
-    for _, n in ipairs(haystack) do
-      if n == needle then
-        return true
-      end
-    end
-    return false
-  end
-
+  -- init
   for i, path in ipairs(params.paths) do
     child.cmd('edit tests/dir/' .. path.src)
 
@@ -45,7 +46,13 @@ local do_dart_test = function(params)
     end
   end
 
-  eq(eval_tabline(), params.wanted)
+  -- checks
+  if params['vim.opt.showtabline'] then
+    eq(params['vim.opt.showtabline'], child.api.nvim_get_option_value('showtabline', {}))
+  end
+  if params.wanted then
+    eq(eval_tabline(), params.wanted)
+  end
 end
 
 local T = set {
@@ -58,7 +65,7 @@ local T = set {
   },
 }
 
-T['gen_tabline() with buflist'] = set {
+T['with buflist'] = set {
   parametrize = {
     {
       {
@@ -97,7 +104,7 @@ T['gen_tabline() with buflist'] = set {
   },
 }
 
-T['gen_tabline() with marklist'] = set {
+T['with marklist'] = set {
   parametrize = {
     {
       {
@@ -137,7 +144,7 @@ T['gen_tabline() with marklist'] = set {
   },
 }
 
-T['gen_tabline() with config custom mark/buflist'] = set {
+T['with config custom mark/buflist'] = set {
   parametrize = {
     {
       {
@@ -173,7 +180,7 @@ T['gen_tabline() with config custom mark/buflist'] = set {
   },
 }
 
-T['gen_tabline() with config no buflist'] = set {
+T['with config no buflist'] = set {
   parametrize = {
     {
       {
@@ -198,7 +205,7 @@ T['gen_tabline() with config no buflist'] = set {
   },
 }
 
-T['gen_tabline() with truncate_tabline'] = set {
+T['with truncate_tabline'] = set {
   parametrize = {
     {
       {
@@ -218,7 +225,7 @@ T['gen_tabline() with truncate_tabline'] = set {
   },
 }
 
-T['gen_tabline() with close_all'] = set {
+T['with close_all'] = set {
   parametrize = {
     {
       {
@@ -239,7 +246,7 @@ T['gen_tabline() with close_all'] = set {
   },
 }
 
-T['gen_tabline() with bad path'] = set {
+T['with bad path'] = set {
   parametrize = {
     {
       {
@@ -250,6 +257,94 @@ T['gen_tabline() with bad path'] = set {
         },
         -- %% here will get escaped correctly in tabline
         wanted = ' z bad%%.dir/init.lua  x dir1/init.lua  c 1.lua ',
+      },
+    },
+  },
+}
+
+T['init with always_show'] = set {
+  parametrize = {
+    {
+      {
+        paths = {},
+        ['vim.opt.showtabline'] = 2,
+      },
+    },
+    {
+      {
+        paths = {
+          { src = 'unix/dir1/1.lua' },
+        },
+        ['vim.opt.showtabline'] = 2,
+      },
+    },
+  },
+}
+
+T['init with always_show=false'] = set {
+  parametrize = {
+    {
+      {
+        paths = {},
+        config = { tabline = { always_show = false } },
+        ['vim.opt.showtabline'] = 1,
+      },
+    },
+    {
+      {
+        paths = {
+          { src = 'unix/dir1/1.lua' },
+        },
+        config = { tabline = { always_show = false } },
+        ['vim.opt.showtabline'] = 2,
+      },
+    },
+    {
+      {
+        paths = {
+          { src = 'unix/dir1/1.lua' },
+        },
+        type_keys = { [1] = ';u' },
+        config = { tabline = { always_show = false } },
+        ['vim.opt.showtabline'] = 2,
+      },
+    },
+  },
+}
+
+T['init with always_show=false and no buflist'] = set {
+  parametrize = {
+    {
+      {
+        paths = {
+          { src = 'unix/dir1/1.lua' },
+          { src = 'unix/dir1/2.lua' },
+        },
+        type_keys = { [2] = ';u' },
+        config = { buflist = {}, tabline = { always_show = false } },
+        ['vim.opt.showtabline'] = 2,
+      },
+    },
+    {
+      {
+        paths = {
+          { src = 'unix/dir1/1.lua' },
+          { src = 'unix/dir1/2.lua', tab = true },
+        },
+        type_keys = { [2] = ';u' },
+        config = { buflist = {}, tabline = { always_show = false } },
+        ['vim.opt.showtabline'] = 2,
+      },
+    },
+    {
+      {
+        paths = {
+          { src = 'unix/dir1/1.lua' },
+          { src = 'unix/dir1/2.lua', tab = true },
+        },
+        mark_after = { 1 },
+        config = { buflist = {}, tabline = { always_show = false } },
+        ['vim.opt.showtabline'] = 2,
       },
     },
   },


### PR DESCRIPTION
Closes #18 

The first commit adds some unit tests for these cases to set a baseline for current behavior. 

However, we should expect the first two tests under `init with always_show=false and no buflist` to have a tabline=2. The expected values for those tests is updated in the second commit and pass after our changes.

The second commit combines the two autocmds under `DartChanged` and the init_tabline function into a `draw_tabline` function, that checks for state > 0 or always_show and only shows the tabline (=2) if so. If not, it's set to =1, which will still display the tabline in the event there is a second tabpage, but otherwise will not.

`draw_tabline` checks the current showtabline setting first and only updates as needed, to avoid extra CPU cycles. It always calls vim.cmd.redrawtabline() at the end.
