### PR TITLE
feat: add `<CR>` keybinding to jump in picker window

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ dart.nvim is a minimalist tabline focused on pinning buffers for fast switching 
 
 ⦿ Cycle through the tabline with `Dart.next` and `Dart.prev` as a replacement for `gt`/`:bnext`, or jump to a specific buffer by character with `Dart.jump`
 
-⦿ Simple `Dart.pick` 'picker' to jump to any marked buffer with a single keystroke
+⦿ Simple `Dart.pick` 'picker' to jump to any marked buffer with a single keystroke, or navigate to one and jump with the `<CR>` key
 
 ⦿ Basic session persistence integrates with plugins like `mini.sessions`
 
@@ -313,7 +313,7 @@ Jumps to the buffer assigned to the given `char` mark.
 
 ### `Dart.pick()`
 
-Opens a floating picker window that lists all active marks. Jump to one by pressing the corresponding key.
+Opens a floating picker window that lists all active marks. Jump to one by pressing the corresponding key or navigate to one and jump with the `<CR>` key.
 
 ### `Dart.read_session(name)`
 

--- a/lua/dart/init.lua
+++ b/lua/dart/init.lua
@@ -709,6 +709,15 @@ Dart.pick = function()
     table.insert(prompt, entry)
   end
 
+  vim.keymap.set('n', '<CR>', function()
+    local line = vim.api.nvim_get_current_line()
+    local mark = line:match('^%s*(.-)%s*→')
+    if mark ~= nil then
+      vim.api.nvim_win_close(0, true)
+      Dart.jump(mark)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, prompt)
   for i = 1, #prompt do
     vim.api.nvim_buf_set_extmark(buf, ns, i - 1, 0, {


### PR DESCRIPTION
Add `<CR>` keybinding so we can use `<CR>` to jump to the buffer in picker window too.