### PR TITLE
feat: make picker window winhighlight option configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ require('dart').setup({})
     -- border style for the picker window
     -- See `:h winborder` for options
     border = 'rounded',
+    -- window highlights
+    -- See `:h winhighlight` for options
+    winhighlight = "Normal:Normal,FloatTitle:FloatTitle,FloatBorder:FloatBorder"
   },
 
   -- State persistence. Use Dart.read_session and Dart.write_session manually

--- a/lua/dart/init.lua
+++ b/lua/dart/init.lua
@@ -99,6 +99,9 @@ M.config = {
     -- See `:h winborder` for options
     border = 'rounded',
     select_mapping = '<CR>',
+    -- window highlights
+    -- See `:h winhighlight` for options
+    winhighlight = 'Normal:Normal,FloatTitle:FloatTitle,FloatBorder:FloatBorder',
   },
 
   -- State persistence. Use Dart.read_session and Dart.write_session manually
@@ -820,7 +823,7 @@ Dart.pick = function()
     hl_group = 'DartPickLabel',
   })
 
-  vim.api.nvim_open_win(buf, true, {
+  local win = vim.api.nvim_open_win(buf, true, {
     relative = 'editor',
     width = row_len + 2,
     height = #M.state + 2,
@@ -831,6 +834,10 @@ Dart.pick = function()
     border = M.config.picker.border,
     focusable = true,
   })
+  -- set winhighlight option
+  if M.config.picker.winhighlight ~= nil then
+    vim.api.nvim_set_option_value('winhighlight', M.config.picker.winhighlight, { win = win })
+  end
 end
 
 Dart.next = function()


### PR DESCRIPTION
Add a `winhighlight` option for picker window, so we can style window a bit. like:

```lua
picker = {
  winhighlight = "Normal:DartPickNormal,FloatBorder:DartPickBorder"
}
-- some demo colors
vim.api.nvim_set_hl(0, "DartPickNormal", { fg = "cyan", bg = "#1a1926" })
vim.api.nvim_set_hl(0, "DartPickBorder", { fg = "red", bg = "#1a1926" })
```
<img width="566" height="234" alt="Screenshot 2025-10-19 at 19 33 14" src="https://github.com/user-attachments/assets/a814f414-06ad-4196-9bf7-6d59d89add3a" />
<img width="573" height="232" alt="Screenshot 2025-10-19 at 19 33 57" src="https://github.com/user-attachments/assets/98b38133-07c3-4a33-b4f2-88e9a1858ce7" />
